### PR TITLE
A Test that should fail and a Docker container that Always fails

### DIFF
--- a/Dockerfile.test_failures
+++ b/Dockerfile.test_failures
@@ -1,0 +1,26 @@
+﻿FROM microsoft/dotnet:2.0-sdk
+
+RUN groupadd node && useradd -m -g node node
+
+# install node
+RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list
+RUN apt -y update
+RUN curl -sL https://deb.nodesource.com/setup_8.x | bash -
+RUN apt -y install nodejs
+
+# add the code
+ADD . /tmp/code
+RUN chown -R node:node /tmp/code
+
+# install build deps
+RUN apt -y install sudo make g++ 
+
+# install and test
+USER node
+WORKDIR /tmp/code
+
+RUN rm -fR node_modules build package-lock.json && npm install
+ENV EDGE_USE_CORECLR=1
+
+CMD npm test

--- a/test/104_csx.js
+++ b/test/104_csx.js
@@ -80,6 +80,34 @@ describe('edge-cs', function () {
         });
     });
 
+    it('succeeds with dll from nuget package', function (done) {
+        var func = edge.func(function () {/*
+            #r "Newtonsoft.Json.dll"
+
+            using Newtonsoft.Json;
+            using System.Threading.Tasks;
+
+            public class MyObject
+            {
+                public string Message { get; set; }
+            }
+
+            public class Startup
+            {
+                public async Task<object> Invoke(object input)
+                {
+                    return JsonConvert.DeserializeObject<MyObject>("{ 'message': 'Hello from .NET' }");
+                }
+            }
+        */});
+
+        func("JavaScript", function (error, result) {
+            assert.ifError(error);
+            assert.equal(result.Message, 'Hello from .NET');
+            done();
+        });
+    });
+
     it('succeeds with custom class and method name', function (done) {
         var func = edge.func({
             source: function () {/* 


### PR DESCRIPTION
So it may be more complicated than I thought.

These tests *always* fail. There is no case normalization but it seems like on older versions of the dotnet sdk, edge-js does end up with an all lower-case version of the library-name. As it turns out, ALL of the tests fail now with the newer SDK. Still because of the case sensitivity issue. But I haven't tracked down why now edge-js is getting the package name as a non-lower-cased version when it didn't used to.

Running the included docker image will break... on almost all of the tests.