### PR TITLE
Remove include of discontinued xlocale.h header

### DIFF
--- a/src/CoreCLREmbedding/cpprest/include/asyncrt_utils.h
+++ b/src/CoreCLREmbedding/cpprest/include/asyncrt_utils.h
@@ -38,13 +38,6 @@
 #include <chrono>
 #endif
 
-#ifndef _WIN32
-//#include <boost/algorithm/string.hpp>
-#if !defined(ANDROID) && !defined(__ANDROID__) // CodePlex 269
-#include <xlocale.h>
-#endif
-#endif
-
 /// Various utilities for string conversions and date and time manipulation.
 namespace utility
 {

--- a/src/CoreCLREmbedding/json/casablanca/include/cpprest/asyncrt_utils.h
+++ b/src/CoreCLREmbedding/json/casablanca/include/cpprest/asyncrt_utils.h
@@ -38,13 +38,6 @@
 #include <chrono>
 #endif
 
-#ifndef _WIN32
-//#include <boost/algorithm/string.hpp>
-#if !defined(ANDROID) && !defined(__ANDROID__) // CodePlex 269
-#include <xlocale.h>
-#endif
-#endif
-
 /// Various utilities for string conversions and date and time manipulation.
 namespace utility
 {


### PR DESCRIPTION
## Problem

If you attempt to `npm install edge-js` on Ubuntu 18.04 (and probably 17.10, but that's unconfirmed), you get some variant of this error (see agracio/electron-edge-js#16):

```
make: Entering directory '/home/vadi/Programs/packager-demo/node_modules/electron-edge-js/build'
  TOUCH Release/obj.target/edge_nativeclr.stamp
  CXX(target) Release/obj.target/edge_coreclr/src/common/v8synchronizationcontext.o
  CXX(target) Release/obj.target/edge_coreclr/src/common/callbackhelper.o
  CXX(target) Release/obj.target/edge_coreclr/src/common/edge.o
  CXX(target) Release/obj.target/edge_coreclr/src/CoreCLREmbedding/coreclrembedding.o
In file included from ../src/CoreCLREmbedding/json/casablanca/include/cpprest/json.h:37:0,
                 from ../src/CoreCLREmbedding/coreclrembedding.cpp:8:
../src/CoreCLREmbedding/json/casablanca/include/cpprest/asyncrt_utils.h:44:10: fatal error: xlocale.h: No such file or directory
 #include <xlocale.h>
          ^~~~~~~~~~~
compilation terminated.
edge_coreclr.target.mk:120: recipe for target 'Release/obj.target/edge_coreclr/src/CoreCLREmbedding/coreclrembedding.o' failed
make: *** [Release/obj.target/edge_coreclr/src/CoreCLREmbedding/coreclrembedding.o] Error 1
```

In other words, the file wants to use `xlocale.h`, but it's not present.

## Cause

`xlocale.h` was previously included in `libc6-dev`, until it was removed in August 2017:

https://sourceware.org/ml/libc-alpha/2017-08/msg00010.html

>* The nonstandard header <xlocale.h> has been removed.  Most programs should
>  use <locale.h> instead.  If you have a specific need for the definition of
>  locale_t with no other declarations, please contact
>  libc-alpha@sourceware.org and explain.

A google search reveals that this has caused similar problems for a variety of projects that used this header.

The file is extremely tiny, comprising only the definition of `locale_t`, which has been moved to `locale.h`.

## Changes

The recommendation in the announcement is to use `locale.h` instead. However, the relevant files in `edge-js` already include this header, so the `#include` directives for `xlocale.h` are simply removed.

Even in older versions of libc, `locale.h` includes `xlocale.h`, so these includes were already unnecessary and should not be missed.

Fixes agracio/electron-edge-js#16.