### PR TITLE
Fix for issue that would cause an occasional segmentation fault on Li…

### DIFF
--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -15,6 +15,7 @@ v8::Local<Value> throwV8Exception(const char* format, ...)
 	size_t size = vsnprintf(NULL, 0, format, args);
 	char* message = new char[size + 1];
 
+	va_start(args, format);
 	vsnprintf(message, size + 1, format, args);
 
 	Nan::EscapableHandleScope scope;


### PR DESCRIPTION
…nux if already in an error state in throwV8Exception.  va_list must be reinitialized after each use.