### PR TITLE
Fix GCHandle leaks in Mono and CoreCLR on Func return

### DIFF
--- a/src/CoreCLREmbedding/coreclrfunc.cpp
+++ b/src/CoreCLREmbedding/coreclrfunc.cpp
@@ -5,6 +5,12 @@ CoreClrFunc::CoreClrFunc()
 	functionHandle = NULL;
 }
 
+CoreClrFunc::~CoreClrFunc()
+{
+	DBG("CoreClrFunc::~CoreClrFunc");
+	CoreClrEmbedding::FreeHandle(functionHandle);
+}
+
 NAN_METHOD(coreClrFuncProxy)
 {
     DBG("coreClrFuncProxy");

--- a/src/CoreCLREmbedding/edge.h
+++ b/src/CoreCLREmbedding/edge.h
@@ -121,6 +121,7 @@ class CoreClrFunc
 		static v8::Local<v8::Function> InitializeInstance(CoreClrGcHandle functionHandle);
 
 	public:
+		~CoreClrFunc();
 		static NAN_METHOD(Initialize);
 		v8::Local<v8::Value> Call(v8::Local<v8::Value> payload, v8::Local<v8::Value> callbackOrSync);
 		static void FreeMarshalData(void* marshalData, int payloadType);

--- a/src/mono/clrfunc.cpp
+++ b/src/mono/clrfunc.cpp
@@ -10,6 +10,12 @@ ClrFunc::ClrFunc()
     // empty
 }
 
+ClrFunc::~ClrFunc()
+{
+    DBG("ClrFunc::~ClrFunc");
+    mono_gchandle_free(func);
+}
+
 NAN_METHOD(clrFuncProxy)
 {
     DBG("clrFuncProxy");

--- a/src/mono/edge.h
+++ b/src/mono/edge.h
@@ -124,6 +124,7 @@ private:
     static v8::Local<v8::Object> MarshalCLRObjectToV8(MonoObject* netdata, MonoException** exc);
 
 public:
+    ~ClrFunc();
     static NAN_METHOD(Initialize);
     static v8::Local<v8::Function> Initialize(MonoObject* func);
     v8::Local<v8::Value> Call(v8::Local<v8::Value> payload, v8::Local<v8::Value> callback);

--- a/test/103_net2node.js
+++ b/test/103_net2node.js
@@ -231,11 +231,16 @@ describe('delayed call from node.js to .net', function () {
 				for (var i = 0; i < expected.length; i++) {
 					assert.ok(expected[i] === trace[i]);
 				}
-				ensureNodejsFuncIsCollected(null, function(error, result) {
-					assert.ifError(error);
-					assert.ok(result);
-					done();
-				});
+
+				// Check for collections after the callback is completed
+				// The func is still referenced by the callback context so it won't be collected if we run inline
+				setTimeout(function() {
+					ensureNodejsFuncIsCollected(null, function(error, result) {
+						assert.ifError(error);
+						assert.ok(result);
+						done();
+					});
+				}, 10);
 			}
 		};
 

--- a/test/tests.cs
+++ b/test/tests.cs
@@ -215,7 +215,7 @@ namespace Edge.Tests
             return result;
         }       
 
-        private WeakReference weakRefToNodejsFunc;
+        private static WeakReference weakRefToNodejsFunc;
         public Task<object> InvokeBackAfterCLRCallHasFinished(dynamic input)
         {
             var trace = new List<string>();
@@ -245,19 +245,8 @@ namespace Edge.Tests
 
         public Task<object> EnsureNodejsFuncIsCollected(dynamic input) {
 
-            var succeed = false;
             GC.Collect();
-            try
-            {
-                // Throws an exception if the object the weak reference
-                // points to is GCed.
-                GC.GetGeneration(weakRefToNodejsFunc);
-            }
-            catch(Exception)
-            {
-                // The NodejsFunc is GCed.
-                succeed = true;
-            }
+            var succeed = !weakRefToNodejsFunc.IsAlive;
             weakRefToNodejsFunc = null;            
             var result = new TaskCompletionSource<object>();
             result.SetResult(succeed);


### PR DESCRIPTION
I found a leak when a call to a .Net method returns a `Func<object, Task<object>>` back.  In the Mono and CoreCLR implementations a `GCHandle` was allocated to keep the func alive, but it was never freed.  I added a destructor to `ClrFunc`/`CoreClrFunc` so that the handle will be freed when the Node function is cleaned up in `clrFuncProxyNearDeath`.

There's no issue in the DotNet implementation since it doesn't use `GCHandles`

I was able to come up with a test case that re-produces the issue.  It is a bit hairy since it relies on keeping the `WeakReference` in a `static` and the `--expose-gc` flag being used - but that flag was already being set.  In doing this I found that the `ensureNodejsFuncIsCollected` wasn't correct - it was throwing a `NullReferenceException`, not the exception it really wanted to test for - so I updated that as well.