### PR TITLE
Downgrade Microsoft.CodeAnalysis reference to 2.8.2

### DIFF
--- a/src/double/Edge.js/Edge.js.csproj
+++ b/src/double/Edge.js/Edge.js.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="2.8.2" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
   </ItemGroup>


### PR DESCRIPTION
This is the highest version which does not use `Microsoft.CodeAnalysis.Analyzers` in version 2.6.1 which throws `NullReferenceException`s during the build, and this produces warnings in the "Edge.js" build.

See also https://github.com/dotnet/roslyn-analyzers/issues/1803 for the bug in Microsoft.CodeAnalysis.Analyzers 2.6.1.

See [this previous master build](https://ci.appveyor.com/project/agracio/edge-js/builds/20848632/job/8x47ag730ys7818p#L87) for an example of these warnings.