### PR TITLE
Dispose allocated memory to fix memory leak

### DIFF
--- a/src/CoreCLREmbedding/coreclrnodejsfuncinvokecontext.cpp
+++ b/src/CoreCLREmbedding/coreclrnodejsfuncinvokecontext.cpp
@@ -102,6 +102,8 @@ void CoreClrNodejsFuncInvokeContext::InvokeCallback(void* data)
 
 	DBG("CoreClrNodejsFuncInvokeContext::InvokeCallback - Calling JavaScript function");
 	Nan::Call(Nan::New(*(context->FunctionContext->Func)), Nan::GetCurrentContext()->Global(), 2, argv);
+	// Free allocated memory
+	CoreClrFunc::FreeMarshalData(context->Payload, context->PayloadType);
 	DBG("CoreClrNodejsFuncInvokeContext::InvokeCallback - Called JavaScript function");
 
 	if (tryCatch.HasCaught())

--- a/src/mono/nodejsfuncinvokecontext.cpp
+++ b/src/mono/nodejsfuncinvokecontext.cpp
@@ -76,6 +76,8 @@ void NodejsFuncInvokeContext::CallFuncOnV8Thread(MonoObject* _this, NodejsFunc* 
         Nan::TryCatch tryCatch;
         DBG("NodejsFuncInvokeContext::CallFuncOnV8Thread calling JavaScript function");
         Nan::Call(Nan::New(*(nativeNodejsFunc->Func)), Nan::GetCurrentContext()->Global(), 2, argv);
+       	// Free allocated memory
+    	ClrFunc::FreeMarshalData(context->Payload, context->PayloadType);
         DBG("NodejsFuncInvokeContext::CallFuncOnV8Thread called JavaScript function");
         if (tryCatch.HasCaught()) 
         {

--- a/src/mono/nodejsfuncinvokecontext.cpp
+++ b/src/mono/nodejsfuncinvokecontext.cpp
@@ -76,8 +76,6 @@ void NodejsFuncInvokeContext::CallFuncOnV8Thread(MonoObject* _this, NodejsFunc* 
         Nan::TryCatch tryCatch;
         DBG("NodejsFuncInvokeContext::CallFuncOnV8Thread calling JavaScript function");
         Nan::Call(Nan::New(*(nativeNodejsFunc->Func)), Nan::GetCurrentContext()->Global(), 2, argv);
-       	// Free allocated memory
-    	ClrFunc::FreeMarshalData(context->Payload, context->PayloadType);
         DBG("NodejsFuncInvokeContext::CallFuncOnV8Thread called JavaScript function");
         if (tryCatch.HasCaught()) 
         {


### PR DESCRIPTION
Passing strings as callback from C# -> JS, I was getting a huge memory leak.

Example for 1.000.000 * 15k strings:
![image](https://user-images.githubusercontent.com/4644017/53653757-f0af3380-3c43-11e9-8b74-e7bdb2356e60.png)

with the added lines:
![image](https://user-images.githubusercontent.com/4644017/53653774-fc025f00-3c43-11e9-8f90-bed9c510b4b2.png)

I'm not very familiar with the structure of the entire lib, nor the V8 engine, so please feel free to advise a better way to dispose this allocated memory.