### PR TITLE
CoreCLR on Windows UTF-8 String Marhsalling

### DIFF
--- a/src/double/Edge.js/dotnetcore/coreclrembedding.cs
+++ b/src/double/Edge.js/dotnetcore/coreclrembedding.cs
@@ -875,7 +875,7 @@ public class CoreCLREmbedding
             case V8Type.Boolean:
             case V8Type.Number:
             case V8Type.Date:
-                Marshal.FreeHGlobal(marshalData);
+                Marshal.FreeCoTaskMem(marshalData);
                 break;
 
             case V8Type.Object:
@@ -889,13 +889,13 @@ public class CoreCLREmbedding
                     IntPtr propertyName = Marshal.ReadIntPtr(objectData.propertyNames, i * PointerSize);
 
                     FreeMarshalData(propertyValue, propertyType);
-                    Marshal.FreeHGlobal(propertyName);
+                    Marshal.FreeCoTaskMem(propertyName);
                 }
 
-                Marshal.FreeHGlobal(objectData.propertyTypes);
-                Marshal.FreeHGlobal(objectData.propertyValues);
-                Marshal.FreeHGlobal(objectData.propertyNames);
-                Marshal.FreeHGlobal(marshalData);
+                Marshal.FreeCoTaskMem(objectData.propertyTypes);
+                Marshal.FreeCoTaskMem(objectData.propertyValues);
+                Marshal.FreeCoTaskMem(objectData.propertyNames);
+                Marshal.FreeCoTaskMem(marshalData);
 
                 break;
 
@@ -910,17 +910,17 @@ public class CoreCLREmbedding
                     FreeMarshalData(itemValue, itemType);
                 }
 
-                Marshal.FreeHGlobal(arrayData.itemTypes);
-                Marshal.FreeHGlobal(arrayData.itemValues);
-                Marshal.FreeHGlobal(marshalData);
+                Marshal.FreeCoTaskMem(arrayData.itemTypes);
+                Marshal.FreeCoTaskMem(arrayData.itemValues);
+                Marshal.FreeCoTaskMem(marshalData);
 
                 break;
 
             case V8Type.Buffer:
                 V8BufferData bufferData = Marshal.PtrToStructure<V8BufferData>(marshalData);
 
-                Marshal.FreeHGlobal(bufferData.buffer);
-                Marshal.FreeHGlobal(marshalData);
+                Marshal.FreeCoTaskMem(bufferData.buffer);
+                Marshal.FreeCoTaskMem(marshalData);
 
                 break;
 
@@ -945,19 +945,19 @@ public class CoreCLREmbedding
         else if (clrObject is string)
         {
             v8Type = V8Type.String;
-            return Marshal.StringToHGlobalAnsi((string) clrObject);
+            return Marshal.StringToCoTaskMemUTF8((string) clrObject);
         }
 
         else if (clrObject is char)
         {
             v8Type = V8Type.String;
-            return Marshal.StringToHGlobalAnsi(clrObject.ToString());
+            return Marshal.StringToCoTaskMemUTF8(clrObject.ToString());
         }
 
         else if (clrObject is bool)
         {
             v8Type = V8Type.Boolean;
-            IntPtr memoryLocation = Marshal.AllocHGlobal(sizeof (int));
+            IntPtr memoryLocation = Marshal.AllocCoTaskMem(sizeof (int));
 
             Marshal.WriteInt32(memoryLocation, ((bool) clrObject)
                 ? 1
@@ -968,7 +968,7 @@ public class CoreCLREmbedding
         else if (clrObject is Guid)
         {
             v8Type = V8Type.String;
-            return Marshal.StringToHGlobalAnsi(clrObject.ToString());
+            return Marshal.StringToCoTaskMemUTF8(clrObject.ToString());
         }
 
         else if (clrObject is DateTime)
@@ -987,7 +987,7 @@ public class CoreCLREmbedding
             }
 
             long ticks = (dateTime.Ticks - MinDateTimeTicks)/10000;
-            IntPtr memoryLocation = Marshal.AllocHGlobal(sizeof (double));
+            IntPtr memoryLocation = Marshal.AllocCoTaskMem(sizeof (double));
 
             WriteDouble(memoryLocation, ticks);
             return memoryLocation;
@@ -996,19 +996,19 @@ public class CoreCLREmbedding
         else if (clrObject is DateTimeOffset)
         {
             v8Type = V8Type.String;
-            return Marshal.StringToHGlobalAnsi(clrObject.ToString());
+            return Marshal.StringToCoTaskMemUTF8(clrObject.ToString());
         }
 
         else if (clrObject is Uri)
         {
             v8Type = V8Type.String;
-            return Marshal.StringToHGlobalAnsi(clrObject.ToString());
+            return Marshal.StringToCoTaskMemUTF8(clrObject.ToString());
         }
 
         else if (clrObject is short)
         {
             v8Type = V8Type.Int32;
-            IntPtr memoryLocation = Marshal.AllocHGlobal(sizeof (int));
+            IntPtr memoryLocation = Marshal.AllocCoTaskMem(sizeof (int));
 
             Marshal.WriteInt32(memoryLocation, Convert.ToInt32(clrObject));
             return memoryLocation;
@@ -1017,7 +1017,7 @@ public class CoreCLREmbedding
         else if (clrObject is int)
         {
             v8Type = V8Type.Int32;
-            IntPtr memoryLocation = Marshal.AllocHGlobal(sizeof (int));
+            IntPtr memoryLocation = Marshal.AllocCoTaskMem(sizeof (int));
 
             Marshal.WriteInt32(memoryLocation, (int) clrObject);
             return memoryLocation;
@@ -1026,7 +1026,7 @@ public class CoreCLREmbedding
         else if (clrObject is long)
         {
             v8Type = V8Type.Number;
-            IntPtr memoryLocation = Marshal.AllocHGlobal(sizeof (double));
+            IntPtr memoryLocation = Marshal.AllocCoTaskMem(sizeof (double));
 
             WriteDouble(memoryLocation, Convert.ToDouble((long) clrObject));
             return memoryLocation;
@@ -1035,7 +1035,7 @@ public class CoreCLREmbedding
         else if (clrObject is double)
         {
             v8Type = V8Type.Number;
-            IntPtr memoryLocation = Marshal.AllocHGlobal(sizeof (double));
+            IntPtr memoryLocation = Marshal.AllocCoTaskMem(sizeof (double));
 
             WriteDouble(memoryLocation, (double) clrObject);
             return memoryLocation;
@@ -1044,7 +1044,7 @@ public class CoreCLREmbedding
         else if (clrObject is float)
         {
             v8Type = V8Type.Number;
-            IntPtr memoryLocation = Marshal.AllocHGlobal(sizeof (double));
+            IntPtr memoryLocation = Marshal.AllocCoTaskMem(sizeof (double));
 
             WriteDouble(memoryLocation, Convert.ToDouble((Single) clrObject));
             return memoryLocation;
@@ -1053,13 +1053,13 @@ public class CoreCLREmbedding
         else if (clrObject is decimal)
         {
             v8Type = V8Type.String;
-            return Marshal.StringToHGlobalAnsi(clrObject.ToString());
+            return Marshal.StringToCoTaskMemUTF8(clrObject.ToString());
         }
 
         else if (clrObject is Enum)
         {
             v8Type = V8Type.String;
-            return Marshal.StringToHGlobalAnsi(clrObject.ToString());
+            return Marshal.StringToCoTaskMemUTF8(clrObject.ToString());
         }
 
         else if (clrObject is byte[] || clrObject is IEnumerable<byte>)
@@ -1080,11 +1080,11 @@ public class CoreCLREmbedding
             }
 
             bufferData.bufferLength = buffer.Length;
-            bufferData.buffer = Marshal.AllocHGlobal(buffer.Length*sizeof (byte));
+            bufferData.buffer = Marshal.AllocCoTaskMem(buffer.Length*sizeof (byte));
 
             Marshal.Copy(buffer, 0, bufferData.buffer, bufferData.bufferLength);
 
-            IntPtr destinationPointer = Marshal.AllocHGlobal(V8BufferDataSize);
+            IntPtr destinationPointer = Marshal.AllocCoTaskMem(V8BufferDataSize);
             Marshal.StructureToPtr(bufferData, destinationPointer, false);
 
             return destinationPointer;
@@ -1120,13 +1120,13 @@ public class CoreCLREmbedding
             int counter = 0;
 
             objectData.propertiesCount = keyCount;
-            objectData.propertyNames = Marshal.AllocHGlobal(PointerSize*keyCount);
-            objectData.propertyTypes = Marshal.AllocHGlobal(sizeof (int)*keyCount);
-            objectData.propertyValues = Marshal.AllocHGlobal(PointerSize*keyCount);
+            objectData.propertyNames = Marshal.AllocCoTaskMem(PointerSize*keyCount);
+            objectData.propertyTypes = Marshal.AllocCoTaskMem(sizeof (int)*keyCount);
+            objectData.propertyValues = Marshal.AllocCoTaskMem(PointerSize*keyCount);
 
             foreach (object key in keys)
             {
-                Marshal.WriteIntPtr(objectData.propertyNames, counter*PointerSize, Marshal.StringToHGlobalAnsi(key.ToString()));
+                Marshal.WriteIntPtr(objectData.propertyNames, counter*PointerSize, Marshal.StringToCoTaskMemUTF8(key.ToString()));
                 V8Type propertyType;
                 Marshal.WriteIntPtr(objectData.propertyValues, counter*PointerSize, MarshalCLRToV8(getValue(key), out propertyType));
                 Marshal.WriteInt32(objectData.propertyTypes, counter*sizeof (int), (int) propertyType);
@@ -1134,7 +1134,7 @@ public class CoreCLREmbedding
                 counter++;
             }
 
-            IntPtr destinationPointer = Marshal.AllocHGlobal(V8ObjectDataSize);
+            IntPtr destinationPointer = Marshal.AllocCoTaskMem(V8ObjectDataSize);
             Marshal.StructureToPtr(objectData, destinationPointer, false);
 
             return destinationPointer;
@@ -1157,13 +1157,13 @@ public class CoreCLREmbedding
             }
 
             arrayData.arrayLength = itemValues.Count;
-            arrayData.itemTypes = Marshal.AllocHGlobal(sizeof (int)*arrayData.arrayLength);
-            arrayData.itemValues = Marshal.AllocHGlobal(PointerSize*arrayData.arrayLength);
+            arrayData.itemTypes = Marshal.AllocCoTaskMem(sizeof (int)*arrayData.arrayLength);
+            arrayData.itemValues = Marshal.AllocCoTaskMem(PointerSize*arrayData.arrayLength);
 
             Marshal.Copy(itemTypes.ToArray(), 0, arrayData.itemTypes, arrayData.arrayLength);
             Marshal.Copy(itemValues.ToArray(), 0, arrayData.itemValues, arrayData.arrayLength);
 
-            IntPtr destinationPointer = Marshal.AllocHGlobal(V8ArrayDataSize);
+            IntPtr destinationPointer = Marshal.AllocCoTaskMem(V8ArrayDataSize);
             Marshal.StructureToPtr(arrayData, destinationPointer, false);
 
             return destinationPointer;
@@ -1213,19 +1213,19 @@ public class CoreCLREmbedding
             int counter = 0;
 
             objectData.propertiesCount = propertyAccessors.Count;
-            objectData.propertyNames = Marshal.AllocHGlobal(PointerSize*propertyAccessors.Count);
-            objectData.propertyTypes = Marshal.AllocHGlobal(sizeof (int)*propertyAccessors.Count);
-            objectData.propertyValues = Marshal.AllocHGlobal(PointerSize*propertyAccessors.Count);
+            objectData.propertyNames = Marshal.AllocCoTaskMem(PointerSize*propertyAccessors.Count);
+            objectData.propertyTypes = Marshal.AllocCoTaskMem(sizeof (int)*propertyAccessors.Count);
+            objectData.propertyValues = Marshal.AllocCoTaskMem(PointerSize*propertyAccessors.Count);
 
             foreach (Tuple<string, Func<object, object>> propertyAccessor in propertyAccessors)
             {
-                Marshal.WriteIntPtr(objectData.propertyNames, counter*PointerSize, Marshal.StringToHGlobalAnsi(propertyAccessor.Item1));
+                Marshal.WriteIntPtr(objectData.propertyNames, counter*PointerSize, Marshal.StringToCoTaskMemUTF8(propertyAccessor.Item1));
 
                 V8Type propertyType;
                 if(clrObject.GetType().FullName.StartsWith("System.Reflection"))
                 {
                     propertyType = V8Type.String;
-                    Marshal.WriteIntPtr(objectData.propertyValues, counter*PointerSize, Marshal.StringToHGlobalAnsi(string.Empty));
+                    Marshal.WriteIntPtr(objectData.propertyValues, counter*PointerSize, Marshal.StringToCoTaskMemUTF8(string.Empty));
                 }else
                 {
                     Marshal.WriteIntPtr(objectData.propertyValues, counter*PointerSize, MarshalCLRToV8(propertyAccessor.Item2(clrObject), out propertyType));
@@ -1234,7 +1234,7 @@ public class CoreCLREmbedding
                 counter++;
             }
 
-            IntPtr destinationPointer = Marshal.AllocHGlobal(V8ObjectDataSize);
+            IntPtr destinationPointer = Marshal.AllocCoTaskMem(V8ObjectDataSize);
             Marshal.StructureToPtr(objectData, destinationPointer, false);
 
             return destinationPointer;
@@ -1246,7 +1246,7 @@ public class CoreCLREmbedding
         switch (objectType)
         {
             case V8Type.String:
-                return Marshal.PtrToStringAnsi(v8Object);
+                return Marshal.PtrToStringUTF8(v8Object);
 
             case V8Type.Object:
                 return V8ObjectToExpando(Marshal.PtrToStructure<V8ObjectData>(v8Object));
@@ -1297,7 +1297,7 @@ public class CoreCLREmbedding
                 return buffer;
 
             case V8Type.Exception:
-                string message = Marshal.PtrToStringAnsi(v8Object);
+                string message = Marshal.PtrToStringUTF8(v8Object);
                 return new Exception(message);
 
             default:
@@ -1381,7 +1381,7 @@ public class CoreCLREmbedding
         {
             int propertyType = Marshal.ReadInt32(v8Object.propertyTypes, i * sizeof(int));
             IntPtr propertyNamePointer = Marshal.ReadIntPtr(v8Object.propertyNames, i * PointerSize);
-            string propertyName = Marshal.PtrToStringAnsi(propertyNamePointer);
+            string propertyName = Marshal.PtrToStringUTF8(propertyNamePointer);
             IntPtr propertyValuePointer = Marshal.ReadIntPtr(v8Object.propertyValues, i * PointerSize);
 
             expandoDictionary.Add(propertyName, MarshalV8ToCLR(propertyValuePointer, (V8Type)propertyType));

--- a/test/102_node2net.js
+++ b/test/102_node2net.js
@@ -34,12 +34,12 @@ describe('async call from node.js to .net', function () {
         var payload = {
             a: 1,
             b: 3.1415,
-            c: 'foo',
+            c: 'fooåäö',
             d: true,
             e: false,
             f: new Buffer(10),
-            g: [ 1, 'foo' ],
-            h: { a: 'foo', b: 12 },
+            g: [ 1, 'fooåäö' ],
+            h: { a: 'fooåäö', b: 12 },
             i: function (payload, callback) { },
             j: new Date(Date.UTC(2013, 07, 30))
         };
@@ -61,7 +61,7 @@ describe('async call from node.js to .net', function () {
             assert.equal(typeof result, 'object');
             assert.ok(result.a === 1);
             assert.ok(result.b === 3.1415);
-            assert.ok(result.c === 'foo');
+            assert.ok(result.c === 'fooåäö');
             assert.ok(result.d === true);
             assert.ok(result.e === false);
             assert.equal(typeof result.f, 'object');
@@ -70,9 +70,9 @@ describe('async call from node.js to .net', function () {
             assert.ok(Array.isArray(result.g));
             assert.equal(result.g.length, 2);
             assert.ok(result.g[0] === 1);
-            assert.ok(result.g[1] === 'foo');
+            assert.ok(result.g[1] === 'fooåäö');
             assert.equal(typeof result.h, 'object');
-            assert.ok(result.h.a === 'foo');
+            assert.ok(result.h.a === 'fooåäö');
             assert.ok(result.h.b === 12);
             assert.equal(typeof result.i, 'function');
             assert.equal(typeof result.j, 'object');

--- a/test/103_net2node.js
+++ b/test/103_net2node.js
@@ -51,7 +51,7 @@ describe('async call from .net to node.js', function () {
 				assert.equal(typeof result, 'object');
 				assert.ok(result.a === 1);
 				assert.ok(result.b === 3.1415);
-				assert.ok(result.c === 'foo');
+				assert.ok(result.c === 'fooåäö');
 				assert.ok(result.d === true);
 				assert.ok(result.e === false);
 				assert.equal(typeof result.f, 'object');
@@ -60,9 +60,9 @@ describe('async call from .net to node.js', function () {
 				assert.ok(Array.isArray(result.g));
 				assert.equal(result.g.length, 2);
 				assert.ok(result.g[0] === 1);
-				assert.ok(result.g[1] === 'foo');
+				assert.ok(result.g[1] === 'fooåäö');
 				assert.equal(typeof result.h, 'object');
-				assert.ok(result.h.a === 'foo');
+				assert.ok(result.h.a === 'fooåäö');
 				assert.ok(result.h.b === 12);
 				assert.equal(typeof result.i, 'function');
 				assert.equal(typeof result.j, 'object');
@@ -105,12 +105,12 @@ describe('async call from .net to node.js', function () {
 				var payload = {
 					a: 1,
 					b: 3.1415,
-					c: 'foo',
+					c: 'fooåäö',
 					d: true,
 					e: false,
 					f: new Buffer(10),
-					g: [ 1, 'foo' ],
-					h: { a: 'foo', b: 12 },
+					g: [ 1, 'fooåäö' ],
+					h: { a: 'fooåäö', b: 12 },
 					j: new Date(Date.UTC(2013, 07, 30))
 				};
 				callback(null, payload);

--- a/test/105_node2net_sync.js
+++ b/test/105_node2net_sync.js
@@ -45,12 +45,12 @@ describe('sync call from node.js to .net', function () {
         var payload = {
             a: 1,
             b: 3.1415,
-            c: 'foo',
+            c: 'fooåäö',
             d: true,
             e: false,
             f: new Buffer(10),
-            g: [ 1, 'foo' ],
-            h: { a: 'foo', b: 12 },
+            g: [ 1, 'fooåäö' ],
+            h: { a: 'fooåäö', b: 12 },
             i: function (payload, callback) { },
             j: new Date(Date.UTC(2013,07,30))
         };

--- a/test/double/double_test/DoubleEdge.cs
+++ b/test/double/double_test/DoubleEdge.cs
@@ -72,7 +72,7 @@ namespace double_test
 			        assert.equal(typeof data, 'object');
 			        assert.ok(data.a === 1);
 			        assert.ok(data.b === 3.1415);
-			        assert.ok(data.c === 'foo');
+			        assert.ok(data.c === 'fooåäö');
 			        assert.ok(data.d === true);
 			        assert.ok(data.e === false);
 			        assert.equal(typeof data.f, 'object');
@@ -81,9 +81,9 @@ namespace double_test
 			        assert.ok(Array.isArray(data.g));
 			        assert.equal(data.g.length, 2);
 			        assert.ok(data.g[0] === 1);
-			        assert.ok(data.g[1] === 'foo');
+			        assert.ok(data.g[1] === 'fooåäö');
 			        assert.equal(typeof data.h, 'object');
-			        assert.ok(data.h.a === 'foo');
+			        assert.ok(data.h.a === 'fooåäö');
 			        assert.ok(data.h.b === 12);
 			        assert.equal(typeof data.i, 'function');
 			        assert.equal(typeof data.j, 'object');
@@ -114,12 +114,12 @@ namespace double_test
                     cb(null, {
 			            a: 1,
 			            b: 3.1415,
-			            c: 'foo',
+			            c: 'fooåäö',
 			            d: true,
 			            e: false,
 			            f: new Buffer(10),
-			            g: [ 1, 'foo' ],
-			            h: { a: 'foo', b: 12 },
+			            g: [ 1, 'fooåäö' ],
+			            h: { a: 'fooåäö', b: 12 },
 			            i: function (payload, callback) { },
 			            j: new Date(Date.UTC(2013, 07, 30))
 		            });

--- a/test/tests.cs
+++ b/test/tests.cs
@@ -53,7 +53,7 @@ namespace Edge.Tests
                 double b = (double)data["b"];
                 if (b != 3.1415) throw new Exception("b is not 3.1415");
                 string c = (string)data["c"];
-                if (c != "foo") throw new Exception("c is not foo");
+                if (c != "fooåäö") throw new Exception("c is not fooåäö");
                 bool d = (bool)data["d"];
                 if (d != true) throw new Exception("d is not true");
                 bool e = (bool)data["e"];
@@ -63,9 +63,9 @@ namespace Edge.Tests
                 object[] g = (object[])data["g"];
                 if (g.Length != 2) throw new Exception("g.length is not 2");
                 if ((int)g[0] != 1) throw new Exception("g[0] is not 1");
-                if ((string)g[1] != "foo") throw new Exception("g[1] is not foo");
+                if ((string)g[1] != "fooåäö") throw new Exception("g[1] is not fooåäö");
                 IDictionary<string, object> h = (IDictionary<string,object>)data["h"];
-                if ((string)h["a"] != "foo") throw new Exception("h.a is not foo");
+                if ((string)h["a"] != "fooåäö") throw new Exception("h.a is not fooåäö");
                 if ((int)h["b"] != 12) throw new Exception("h.b is not 12");
                 if (expectFunction)
                 {
@@ -86,7 +86,7 @@ namespace Edge.Tests
                 double b = input.b;
                 if (b != 3.1415) throw new Exception("dynamic b is not 3.1415");
                 string c = input.c;
-                if (c != "foo") throw new Exception("dynamic c is not foo");
+                if (c != "fooåäö") throw new Exception("dynamic c is not fooåäö");
                 bool d = input.d;
                 if (d != true) throw new Exception("dynamic d is not true");
                 bool e = input.e;
@@ -96,9 +96,9 @@ namespace Edge.Tests
                 dynamic[] g = input.g;
                 if (g.Length != 2) throw new Exception("dynamic g.length is not 2");
                 if ((int)g[0] != 1) throw new Exception("dynamic g[0] is not 1");
-                if ((string)g[1] != "foo") throw new Exception("dynamic g[1] is not foo");
+                if ((string)g[1] != "fooåäö") throw new Exception("dynamic g[1] is not fooåäö");
                 dynamic h = input.h;
-                if ((string)h.a != "foo") throw new Exception("dynamic h.a is not foo");
+                if ((string)h.a != "fooåäö") throw new Exception("dynamic h.a is not fooåäö");
                 if ((int)h.b != 12) throw new Exception("dynamic h.b is not 12");
                 if (expectFunction)
                 {
@@ -131,12 +131,12 @@ namespace Edge.Tests
             dynamic result = new ExpandoObject();
             result.a = 1;
             result.b = 3.1415;
-            result.c = "foo";
+            result.c = "fooåäö";
             result.d = true;
             result.e = false;
             result.f = new byte[10];
-            result.g = new object[] { 1, "foo" };
-            result.h = new { a = "foo", b = 12 };
+            result.g = new object[] { 1, "fooåäö" };
+            result.h = new { a = "fooåäö", b = 12 };
             result.i = (Func<object,Task<object>>)(async (i) => { return i; });
             result.j = new DateTime(2013, 08, 30);
 
@@ -180,12 +180,12 @@ namespace Edge.Tests
             dynamic payload = new ExpandoObject();
             payload.a = 1;
             payload.b = 3.1415;
-            payload.c = "foo";
+            payload.c = "fooåäö";
             payload.d = true;
             payload.e = false;
             payload.f = new byte[10];
-            payload.g = new object[] { 1, "foo" };
-            payload.h = new { a = "foo", b = 12 };
+            payload.g = new object[] { 1, "fooåäö" };
+            payload.h = new { a = "fooåäö", b = 12 };
             payload.i = (Func<object,Task<object>>)(async (i) => { return i; });
             payload.j = new DateTime(2013, 08, 30);
 


### PR DESCRIPTION
Fixes some issues with utf8 string marshaling in Windows.  On OSX/Linux the default string marshaling is already utf8, but on Windows the default is the system code page.  So strings with non-ASCII characters would get managed on Windows, but were fine in OSX/Linux.

Marshaling strings to utf8 is only supported with the `CoTaskMem` allocator, so I switched all of the allocations from `HGlocal` to `CoTaskMem` to keep things consistent.  In CoreCLR they should really hit the same heap, but CoTaskMem should technically be faster - see https://github.com/dotnet/corefx/issues/31018#issuecomment-405250414

This should also resolve https://github.com/agracio/edge-js/issues/50.  That was due to a bug in the CoreCLR's marshaling code that is getting fixed in CoreCLR 3.0 - https://github.com/dotnet/coreclr/issues/22394.  So `EdgeBootstrapperContext` has to be manually marshaled to work in CoreCLR 1.x/2.x.