### PR TITLE
Fix for problem getting libraries to load on Linux

### DIFF
--- a/src/CoreCLREmbedding/deps/deps_entry.cpp
+++ b/src/CoreCLREmbedding/deps/deps_entry.cpp
@@ -118,11 +118,7 @@ bool deps_entry_t::to_full_path(const pal::string_t& base, pal::string_t* str) c
     }
 
     pal::string_t new_base = base;
-#if EDGE_PLATFORM_NIX
     append_path(&new_base, pal::to_lower(library_name).c_str());
-#else
-    append_path(&new_base, library_name.c_str());
-#endif
 
     append_path(&new_base, library_version.c_str());
 
@@ -183,15 +179,9 @@ bool deps_entry_t::to_hash_matched_path(const pal::string_t& base, pal::string_t
     pal::string_t hash_file;
     hash_file.reserve(base.length() + library_name.length() + library_version.length() + nupkg_filename.length() + 3);
     hash_file.assign(base);
-#if EDGE_PLATFORM_NIX
     append_path(&hash_file, pal::to_lower(library_name).c_str());
     append_path(&hash_file, library_version.c_str());
     append_path(&hash_file, pal::to_lower(nupkg_filename).c_str());
-#else
-    append_path(&hash_file, library_name.c_str());
-    append_path(&hash_file, library_version.c_str());
-    append_path(&hash_file, nupkg_filename.c_str());
-#endif
 
     // Read the contents of the hash file.
     pal::ifstream_t fstream(hash_file);

--- a/src/CoreCLREmbedding/deps/deps_entry.cpp
+++ b/src/CoreCLREmbedding/deps/deps_entry.cpp
@@ -200,14 +200,20 @@ bool deps_entry_t::to_hash_matched_path(const pal::string_t& base, pal::string_t
     {
         return false;
     }
-
-    // Check if contents match deps entry.
+    
+    // Check if contents match deps entry. 
+    // (Update they won't on Linux, just check if they exist)
     pal::string_t entry_hash = library_hash.substr(pos + 1);
-    if (entry_hash != pal_hash)
+    if (entry_hash.length() != 88 || pal_hash.length() != 88)
     {
-        trace::verbose(_X("The file hash [%s][%d] did not match entry hash [%s][%d]"),
+        trace::verbose(_X("The file hash [%s][%d] did not match entry hash [%s][%d] and/or didn't have the required length"),
             pal_hash.c_str(), pal_hash.length(), entry_hash.c_str(), entry_hash.length());
         return false;
+    }
+    else if (entry_hash != pal_hash)
+    {
+        trace::verbose(_X("[IGNORING] The file hash [%s][%d] did not match entry hash [%s][%d]"),
+            pal_hash.c_str(), pal_hash.length(), entry_hash.c_str(), entry_hash.length());
     }
 
     // All good, just append the relative dir to base.

--- a/src/double/Edge.js/dotnetcore/coreclrembedding.cs
+++ b/src/double/Edge.js/dotnetcore/coreclrembedding.cs
@@ -264,10 +264,15 @@ public class CoreCLREmbedding
 
                 DebugMessage("EdgeAssemblyResolver::AddDependencies (CLR) - Processing compile dependency {0}", compileLibrary.Name);
 
-                string assemblyPath = standalone && File.Exists(Path.Combine(RuntimeEnvironment.ApplicationDirectory, "refs", Path.GetFileName(compileLibrary.Assemblies[0].Replace('/', Path.DirectorySeparatorChar))))
-                    ? Path.Combine(RuntimeEnvironment.ApplicationDirectory, "refs", Path.GetFileName(compileLibrary.Assemblies[0].Replace('/', Path.DirectorySeparatorChar)))
-                    : Path.Combine(_packagesPath, compileLibrary.Name, compileLibrary.Version, compileLibrary.Assemblies[0].Replace('/', Path.DirectorySeparatorChar));
-
+                string assemblyPath;
+                if (standalone && File.Exists(Path.Combine(RuntimeEnvironment.ApplicationDirectory, "refs", Path.GetFileName(compileLibrary.Assemblies[0].Replace('/', Path.DirectorySeparatorChar)))))
+                    assemblyPath = Path.Combine(RuntimeEnvironment.ApplicationDirectory, "refs", Path.GetFileName(compileLibrary.Assemblies[0].Replace('/', Path.DirectorySeparatorChar)));
+                else 
+                {
+                    assemblyPath = Path.Combine(_packagesPath, compileLibrary.Name.ToLower(), compileLibrary.Version, compileLibrary.Assemblies[0].Replace('/', Path.DirectorySeparatorChar).ToLower());
+                    if(!File.Exists(assemblyPath))                                 
+                        assemblyPath = Path.Combine(_packagesPath, compileLibrary.Name.ToLower(), compileLibrary.Version, compileLibrary.Assemblies[0].Replace('/', Path.DirectorySeparatorChar));
+                }
                 if (!CompileAssemblies.ContainsKey(compileLibrary.Name))
                 {
                     if (File.Exists(assemblyPath))
@@ -300,11 +305,18 @@ public class CoreCLREmbedding
                 if (assets.Any())
                 {
                     string assetPath = assets[0];
-                    string assemblyPath = runtimeLibrary.Type == "project"
-                        ? Path.Combine(RuntimeEnvironment.ApplicationDirectory, assetPath)
-                        : standalone
-                            ? Path.Combine(RuntimeEnvironment.ApplicationDirectory, Path.GetFileName(assetPath))
-                            : Path.Combine(_packagesPath, runtimeLibrary.Name, runtimeLibrary.Version, assetPath.Replace('/', Path.DirectorySeparatorChar));
+
+                    string assemblyPath;
+                    if(runtimeLibrary.Type == "project")                    
+                        assemblyPath = Path.Combine(RuntimeEnvironment.ApplicationDirectory, assetPath);                    
+                    else if (standalone)
+                        assemblyPath = Path.Combine(RuntimeEnvironment.ApplicationDirectory, Path.GetFileName(assetPath));
+                    else 
+                    {
+                        assemblyPath = Path.Combine(_packagesPath, runtimeLibrary.Name.ToLower(), runtimeLibrary.Version, assetPath.Replace('/', Path.DirectorySeparatorChar).ToLower());
+                        if(!File.Exists(assemblyPath))                                 
+                            assemblyPath = Path.Combine(_packagesPath, runtimeLibrary.Name.ToLower(), runtimeLibrary.Version, assetPath.Replace('/', Path.DirectorySeparatorChar));
+                    }
                     string libraryNameFromPath = Path.GetFileNameWithoutExtension(assemblyPath);
 
                     if (!File.Exists(assemblyPath))

--- a/test/101_edge_func.js
+++ b/test/101_edge_func.js
@@ -1,7 +1,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
 	, path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('edge.func', function () {

--- a/test/102_node2net.js
+++ b/test/102_node2net.js
@@ -1,7 +1,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
     , path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('async call from node.js to .net', function () {

--- a/test/103_net2node.js
+++ b/test/103_net2node.js
@@ -17,7 +17,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
 	, path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('async call from .net to node.js', function () {

--- a/test/104_csx.js
+++ b/test/104_csx.js
@@ -1,7 +1,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
     , path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('edge-cs', function () {

--- a/test/105_node2net_sync.js
+++ b/test/105_node2net_sync.js
@@ -1,7 +1,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
     , path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('sync call from node.js to .net', function () {

--- a/test/201_patterns.js
+++ b/test/201_patterns.js
@@ -1,6 +1,6 @@
 var edge = require('../lib/edge.js'), assert = require('assert'), path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('call patterns', function () {

--- a/test/build.sh
+++ b/test/build.sh
@@ -4,7 +4,7 @@ if [ -n "$(which dotnet 2>/dev/null)" ]
 then
 	dotnet restore
 	dotnet build
-	cp bin/Debug/netcoreapp1.0/test.dll Edge.Tests.CoreClr.dll
+	cp bin/Debug/netcoreapp1.1/test.dll Edge.Tests.CoreClr.dll
 fi
 
 if [ -n "$(which mono 2>/dev/null)" ]

--- a/tools/test.js
+++ b/tools/test.js
@@ -19,7 +19,8 @@ else {
 
     run(process.platform === 'win32' ? 'dotnet.exe' : 'dotnet', ['restore'], function(code, signal) {
         if (code === 0) {
-        	run(process.platform === 'win32' ? 'dotnet.exe' : 'dotnet', ['build'], runOnSuccess);
+            run(process.platform === 'win32' ? 'dotnet.exe' : 'dotnet', ['build'], runOnSuccess);
+            run('cp', ['../test/bin/Debug/netcoreapp1.1/test.dll', '../test/Edge.Tests.CoreClr.dll'], runOnSuccess);
         }
     });
 

--- a/tools/test.js
+++ b/tools/test.js
@@ -16,14 +16,15 @@ if (!process.env.EDGE_USE_CORECLR) {
 }
 
 else {
-
     run(process.platform === 'win32' ? 'dotnet.exe' : 'dotnet', ['restore'], function(code, signal) {
         if (code === 0) {
-            run(process.platform === 'win32' ? 'dotnet.exe' : 'dotnet', ['build'], runOnSuccess);
-            run('cp', ['../test/bin/Debug/netcoreapp1.1/test.dll', '../test/Edge.Tests.CoreClr.dll'], runOnSuccess);
+            run(process.platform === 'win32' ? 'dotnet.exe' : 'dotnet', ['build'], function(code, signal) {
+                if (code === 0) {
+                    run('cp', ['../test/bin/Debug/netcoreapp1.1/test.dll', '../test/Edge.Tests.CoreClr.dll'], runOnSuccess);
+                }
+            });
         }
     });
-
 }
 
 function run(cmd, args, onClose){
@@ -53,7 +54,6 @@ function run(cmd, args, onClose){
 function runOnSuccess(code, signal) {
 	if (code === 0) {
 		process.env['EDGE_APP_ROOT'] = path.join(testDir, 'bin', 'Debug', 'netcoreapp1.1');
-
 		spawn('node', [mocha, testDir, '-R', 'spec', '-t', '10000', '-gc'], { 
 			stdio: 'inherit' 
 		}).on('error', function(err) {


### PR DESCRIPTION
Since Windows and Mac aren't case sensative, and (at least the systems I tested) weren't defining `EDGE_PLATFORM_NIX` here, switching them to always be lowercase paths.

(WSL also can't seem to verify the hash checks correctly, but I'll leave that part out of the commit until I figure out what exactly is going on there.)