### PR TITLE
Fixed hash check for packages downloaded from Nuget.com

### DIFF
--- a/src/CoreCLREmbedding/deps/deps_entry.cpp
+++ b/src/CoreCLREmbedding/deps/deps_entry.cpp
@@ -251,8 +251,8 @@ bool deps_entry_t::to_hash_matched_path(const pal::string_t& base, pal::string_t
     // Check if contents match deps entry. 
     if (entry_hash != pal_hash)
     {
-        //trace::verbose(_X("The file hash [%s][%d] did not match entry hash [%s][%d]"),
-        //    pal_hash.c_str(), pal_hash.length(), entry_hash.c_str(), entry_hash.length());
+        trace::verbose(_X("The file hash [%s][%d] did not match entry hash [%s][%d]"),
+            pal_hash.c_str(), pal_hash.length(), entry_hash.c_str(), entry_hash.length());
         return false;
     }
 

--- a/src/CoreCLREmbedding/deps/deps_entry.cpp
+++ b/src/CoreCLREmbedding/deps/deps_entry.cpp
@@ -4,6 +4,7 @@
 #include "../pal/pal.h"
 #include "../pal/pal_utils.h"
 #include "deps_entry.h"
+#include "deps_format.h"
 #include "../pal/trace.h"
 
 
@@ -165,6 +166,52 @@ bool deps_entry_t::to_hash_matched_path(const pal::string_t& base, pal::string_t
         trace::verbose(_X("Invalid hash %s value for deps file entry: %s"), library_hash.c_str(), library_name.c_str());
         return false;
     }
+    pal::string_t entry_hash = library_hash.substr(pos + 1);
+
+    // If downloaded from NuGet.com, package will be signed, so need to get the original hash from the metadata file    
+    const pal::string_t nupkg_metadata_filename = _X(".nupkg.metadata");
+    pal::string_t nupkg_metadata_file;
+    nupkg_metadata_file.reserve(base.length() + library_name.length() + library_version.length() + nupkg_metadata_filename.length() + 3);
+    nupkg_metadata_file.assign(base);
+    append_path(&nupkg_metadata_file, pal::to_lower(library_name).c_str());
+    append_path(&nupkg_metadata_file, library_version.c_str());
+    append_path(&nupkg_metadata_file, nupkg_metadata_filename.c_str());
+
+    if (pal::file_exists(nupkg_metadata_file))
+    {
+        // Read the contents of the metadata file.
+        pal::ifstream_t nupkg_metadata_fs(nupkg_metadata_file);
+        if (!nupkg_metadata_fs.good())
+        {
+            trace::verbose(_X("The hash metadata file is invalid [%s]"), nupkg_metadata_file.c_str());
+            return false;
+        }
+        else
+        {
+            try
+            {
+                // Get the "contentHash" value for the pre-signed hash value
+                const auto metadata_json = web::json::value::parse(nupkg_metadata_fs);
+                const auto& content_hash = metadata_json.at(_X("contentHash")).as_string();
+                if(content_hash != entry_hash)            
+                {
+                    trace::verbose(_X("The metadata hash [%s][%d] did not match entry hash [%s][%d]"),
+                        content_hash.c_str(), content_hash.length(), entry_hash.c_str(), entry_hash.length());
+                }
+                else
+                {          
+                    // All good, just append the relative dir to base.
+                    return to_full_path(base, &candidate);
+                }
+            }
+            catch (const std::exception& je)
+            {
+                pal::string_t jes;
+                (void) pal::utf8_palstring(je.what(), &jes);
+                trace::error(_X("A JSON parsing exception occurred in [%s]: %s"), nupkg_metadata_file.c_str(), jes.c_str());
+            }
+        }
+    }
 
     // Build the nupkg file name. Just reserve approx 8 char_t's for the algorithm name.
     pal::string_t nupkg_filename;
@@ -202,18 +249,11 @@ bool deps_entry_t::to_hash_matched_path(const pal::string_t& base, pal::string_t
     }
     
     // Check if contents match deps entry. 
-    // (Update they won't on Linux, just check if they exist)
-    pal::string_t entry_hash = library_hash.substr(pos + 1);
-    if (entry_hash.length() != 88 || pal_hash.length() != 88)
+    if (entry_hash != pal_hash)
     {
-        trace::verbose(_X("The file hash [%s][%d] did not match entry hash [%s][%d] and/or didn't have the required length"),
-            pal_hash.c_str(), pal_hash.length(), entry_hash.c_str(), entry_hash.length());
+        //trace::verbose(_X("The file hash [%s][%d] did not match entry hash [%s][%d]"),
+        //    pal_hash.c_str(), pal_hash.length(), entry_hash.c_str(), entry_hash.length());
         return false;
-    }
-    else if (entry_hash != pal_hash)
-    {
-        trace::verbose(_X("[IGNORING] The file hash [%s][%d] did not match entry hash [%s][%d]"),
-            pal_hash.c_str(), pal_hash.length(), entry_hash.c_str(), entry_hash.length());
     }
 
     // All good, just append the relative dir to base.

--- a/src/double/Edge.js/Edge.js.csproj
+++ b/src/double/Edge.js/Edge.js.csproj
@@ -55,7 +55,6 @@
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />

--- a/test/101_edge_func.js
+++ b/test/101_edge_func.js
@@ -1,7 +1,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
 	, path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('edge.func', function () {

--- a/test/102_node2net.js
+++ b/test/102_node2net.js
@@ -1,7 +1,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
     , path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('async call from node.js to .net', function () {

--- a/test/103_net2node.js
+++ b/test/103_net2node.js
@@ -17,7 +17,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
 	, path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('async call from .net to node.js', function () {

--- a/test/104_csx.js
+++ b/test/104_csx.js
@@ -1,7 +1,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
     , path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('edge-cs', function () {
@@ -530,7 +530,7 @@ describe('edge-cs', function () {
     }
 
     if (process.env.EDGE_USE_CORECLR) {
-        it.skip(prefix + ' fails when dynamically loading an assembly that doesn\'t exist', function () {
+        it(prefix + ' fails when dynamically loading an assembly that doesn\'t exist', function (done) {
             assert.throws(function() {
                 var func = edge.func({
                     source: function () {/* 
@@ -553,11 +553,14 @@ describe('edge-cs', function () {
                 });
 
                 func("JavaScript");
+                done();
             },
             function (error) {
                 if ((error instanceof Error) && error.message.match(/Could not load the specified file/)) {
+                    done();
                     return true;
                 }
+                done();
                 return false;
             },
             'Unexpected result');

--- a/test/105_node2net_sync.js
+++ b/test/105_node2net_sync.js
@@ -1,7 +1,7 @@
 var edge = require('../lib/edge.js'), assert = require('assert')
     , path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('sync call from node.js to .net', function () {

--- a/test/201_patterns.js
+++ b/test/201_patterns.js
@@ -1,6 +1,6 @@
 var edge = require('../lib/edge.js'), assert = require('assert'), path = require('path');
 
-var edgeTestDll = process.env.EDGE_USE_CORECLR ? path.join(__dirname, 'Edge.Tests.CoreClr.dll') : path.join(__dirname, 'Edge.Tests.dll');
+var edgeTestDll = process.env.EDGE_USE_CORECLR ? 'test' : path.join(__dirname, 'Edge.Tests.dll');
 var prefix = process.env.EDGE_USE_CORECLR ? '[CoreCLR]' : process.platform === 'win32' ? '[.NET]' : '[Mono]';
 
 describe('call patterns', function () {

--- a/test/test.csproj
+++ b/test/test.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="System.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="System.Runtime.InteropServices" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
     <PackageReference Include="System.Xml.XPath.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="System.Xml.ReaderWriter" Version="4.3.1" />


### PR DESCRIPTION
So I have found an answer for why `.deps.json` files hashes don't match with the `.sha512` files in the nuget packages. 

Turns out NuGet started signing packages downloaded from their site and rehashing them, which makes the hash not match. However, there is a `.nupkg.metadata` file in the package folder that is json with a `contentHash` value, which has the hash from before it was signed. 

So I fixed that and now the hash checking works