### PR TITLE
Added support for arm64

### DIFF
--- a/src/CoreCLREmbedding/coreclrembedding.cpp
+++ b/src/CoreCLREmbedding/coreclrembedding.cpp
@@ -87,6 +87,8 @@ pal::string_t GetOSArchitecture()
 	return _X("x64");
 #elif defined ARM || defined __arm__ || defined _ARM
 	return _X("arm");
+#elif defined __aarch64__ || defined _M_ARM64 || __ARM_ARCH_ISA_A64 
+	return _X("arm64");
 #endif
 }
 


### PR DESCRIPTION
When using edge-js with an ARM64 embedded board, you are presented with a segmentation fault.

```
# uname -a
Linux NanoPi-NEO2 4.14.52 #1 SMP Thu Oct 11 15:51:48 CST 2018 aarch64 aarch64 aarch64 GNU/Linux
``` 

With this new directives, I managed to get it running and all my integration tests passed.

Tested with both real hardware (NanoPi Neo2) and docker with qemu emulation.