### PR TITLE
Force standard Windows stack size for v8 thread

### DIFF
--- a/src/double/Edge.js/dotnet/EdgeJs.cs
+++ b/src/double/Edge.js/dotnet/EdgeJs.cs
@@ -118,7 +118,7 @@ namespace EdgeJs
                             argv.Add($"-EdgeJs:{Path.Combine(edgeDirectory, "EdgeJs.dll")}");
                             nodeStart(argv.Count, argv.ToArray());
                             waitHandle.Set();
-                        });
+                        }, 1048576); // Force typical Windows stack size because less is liable to break
 
                         v8Thread.IsBackground = true;
                         v8Thread.Start();


### PR DESCRIPTION
Force the stack size for v8 to 1Mb. Fixes stack overflows that can occur on IIS which shrinks the stack to much lower than this by default.

Fixes #114