### PR TITLE
allow downloader to follow redirects

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "edge-cs": "1.2.1",
+    "follow-redirects": "^1.13.0",
     "nan": "^2.14.0"
   },
   "devDependencies": {

--- a/tools/download.js
+++ b/tools/download.js
@@ -1,4 +1,4 @@
-var http = require('http');
+var {http} = require('follow-redirects');
 
 var urls;
 if (process.argv[2] === 'x86') {


### PR DESCRIPTION
I was getting 301 errors with building a custom version of edge using tools/build.bat. This allows the downloader to follow those redirects and solves those errors.