### PR TITLE
Fix for concurrent accesses of the internal caches

### DIFF
--- a/src/double/Edge.js.CSharp/EdgeCompiler.cs
+++ b/src/double/Edge.js.CSharp/EdgeCompiler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,7 +18,7 @@ public class EdgeCompiler
     private static readonly bool DebuggingEnabled = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("EDGE_CS_DEBUG"));
     private static readonly bool DebuggingSelfEnabled = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("EDGE_CS_DEBUG_SELF"));
     private static readonly bool CacheEnabled = !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("EDGE_CS_CACHE"));
-    private static readonly Dictionary<string, Func<object, Task<object>>> FuncCache = new Dictionary<string, Func<object, Task<object>>>();
+    private static readonly ConcurrentDictionary<string, Func<object, Task<object>>> FuncCache = new ConcurrentDictionary<string, Func<object, Task<object>>>();
     private static Func<Stream, Assembly> _assemblyLoader;
 
     public static void SetAssemblyLoader(Func<Stream, Assembly> assemblyLoader)

--- a/src/double/Edge.js/dotnetcore/coreclrembedding.cs
+++ b/src/double/Edge.js/dotnetcore/coreclrembedding.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Runtime.Loader;
 using System.Linq.Expressions;
 using System.Dynamic;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections;
 using System.Threading.Tasks;
@@ -505,12 +506,12 @@ public class CoreCLREmbedding
 
     private static readonly bool DebugMode = Environment.GetEnvironmentVariable("EDGE_DEBUG") == "1";
     private static readonly long MinDateTimeTicks = 621355968000000000;
-    private static readonly Dictionary<Type, List<Tuple<string, Func<object, object>>>> TypePropertyAccessors = new Dictionary<Type, List<Tuple<string, Func<object, object>>>>();
+    private static readonly ConcurrentDictionary<Type, List<Tuple<string, Func<object, object>>>> TypePropertyAccessors = new ConcurrentDictionary<Type, List<Tuple<string, Func<object, object>>>>();
     private static readonly int PointerSize = Marshal.SizeOf<IntPtr>();
     private static readonly int V8BufferDataSize = Marshal.SizeOf<V8BufferData>();
     private static readonly int V8ObjectDataSize = Marshal.SizeOf<V8ObjectData>();
     private static readonly int V8ArrayDataSize = Marshal.SizeOf<V8ArrayData>();
-    private static readonly Dictionary<string, Tuple<Type, MethodInfo>> Compilers = new Dictionary<string, Tuple<Type, MethodInfo>>();
+    private static readonly ConcurrentDictionary<string, Tuple<Type, MethodInfo>> Compilers = new ConcurrentDictionary<string, Tuple<Type, MethodInfo>>();
 
     public static void Initialize(IntPtr context, IntPtr exception)
     {


### PR DESCRIPTION
This is not easilly reproduceable as usual with concurrent issues, however, running our internal test cases, when the build machine was with some load, the following error sometimes appeared:

```
Unhandled exception. System.InvalidOperationException: Operations that change non-concurrent collections must have exclusive access. A concurrent update was performed on this collection and corrupted its state. The collection's state is no longer correct.
   at System.Collections.Generic.Dictionary`2.FindValue(TKey key)
   at CoreCLREmbedding.GetPropertyAccessors(Type type)
   at CoreCLREmbedding.MarshalCLRToV8(Object clrObject, V8Type& v8Type)
   at CoreCLREmbedding.MarshalCLRToV8(Object clrObject, V8Type& v8Type)
   at CoreCLREmbedding.CallFunc(IntPtr function, IntPtr payload, Int32 payloadType, IntPtr taskState, IntPtr result, IntPtr resultType)
```

I was able to (sometimes) reproduce it, by running the same tests at the same time in seperated command windows
`start npm run test & timeout 4 & start npm run test & timeout 4 & start npm run test & timeout 4 & start npm run test`

Nevertheless, this is a common problem when the dictionary is accessed by different threads.
A very easy fix with almost no code changes is to simply change the Dictionary to ConcurrentDictionary.

After this fix, I was unable to reproduce the problem and the application continued to run as before with no visible performance impacts.

Regards