### PR TITLE
Remove return outside of function 

### DIFF
--- a/tools/runJsHint.js
+++ b/tools/runJsHint.js
@@ -55,7 +55,7 @@ filesToLint.forEach(function (filename) {
 });
 
 if (utils.errors > 0) {
-	return process.exit(1);
+	process.exit(1);
 }
 
 console.log('Success: no linting errors.');


### PR DESCRIPTION
To prevent javascript' allow return outside of function validation