### PR TITLE
Bump Newtonsoft.Json package version to 13.0.2

### DIFF
--- a/performance/BookService/packages.config
+++ b/performance/BookService/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="13.0.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
We are consuming edge-js in our project and recently a security alert is generated asking us to bump this version of Newtonsoft.json to 13.0.2.

@agracio @corylulu @shferguson-truefit 
Please approve and release a new version of edge-js to npm.