### PR TITLE
Added support for per-app runtime config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -777,7 +777,9 @@ set EDGE_APP_ROOT=c:\DotNet\MyProject\bin\Release\netstandard1.6
 node app.js
 ```
 
-Edge.js also supports running published .NET Core applications on servers that do not have the .NET Core SDK and CLI installed, which is a common scenario in production environments.  To do so, the `.csproj` for your application should meet the following requirements:
+When calling a compiled assembly, Edge.js supports running with only the .NET runtime installed (and not the SDK or CLI). In this case a `appname.runtimeconfig.json` has to be created when building the project an present in your `EDGE_APP_ROOT` directory. `<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>`should be present under `<PropertyGroup>` in your `.csproj`file to create this file.
+
+Edge.js also supports running published .NET Core applications on servers that do not have the .NET Core SDK and CLI or .NET runtime installed, which is a common scenario in production environments.  To do so, the `.csproj` for your application should meet the following requirements:
 
  1. It should target the `netcoreapp2.x` or `netstandard2.0` framework moniker.
  2. It should reference `Microsoft.NETCore.DotNetHost` and `Microsoft.NETCore.DotNetHostPolicy`.  This is required so that the publish process can provide all the native libraries required to create a completely standalone version of your application.

--- a/src/CoreCLREmbedding/host/runtime_config.cpp
+++ b/src/CoreCLREmbedding/host/runtime_config.cpp
@@ -107,7 +107,7 @@ bool runtime_config_t::parse_opts(const json_value& opts)
     m_fx_name = fx_obj->at(_X("name")).as_string();
     m_fx_ver = fx_obj->at(_X("version")).as_string();
 
-    trace::verbose(_X("Found framework with version [%s] in runtimeconfig.json file"), m_fx_ver);
+    trace::verbose(_X("Found framework [%s] with version [%s] in runtimeconfig.json file"), m_fx_name.c_str(), m_fx_ver.c_str());
 
     return true;
 }

--- a/src/CoreCLREmbedding/host/runtime_config.cpp
+++ b/src/CoreCLREmbedding/host/runtime_config.cpp
@@ -19,6 +19,7 @@ runtime_config_t::runtime_config_t(const pal::string_t& path, const pal::string_
     trace::verbose(_X("Runtime config [%s] is valid=[%d]"), path.c_str(), m_valid);
 } 
 
+// Parse runtimeconfig, see documentation here https://github.com/dotnet/sdk/blob/main/documentation/specs/runtime-configuration-file.md
 bool runtime_config_t::parse_opts(const json_value& opts)
 {
     // Note: both runtime_config and dev_runtime_config call into the function.
@@ -71,17 +72,34 @@ bool runtime_config_t::parse_opts(const json_value& opts)
         m_prerelease_roll_fwd = prerelease_roll_fwd->second.as_bool();
     }
 
-    auto framework =  opts_obj.find(_X("framework"));
-    if (framework == opts_obj.end())
+    auto framework = opts_obj.find(_X("framework"));
+    const web::json::object* fx_obj = nullptr;
+
+    if (framework == opts_obj.end()) // Found no "framework" section in file, trying "frameworks"
     {
-        return true;
+        auto frameworks = opts_obj.find(_X("frameworks"));
+        if (frameworks == opts_obj.end())
+        {
+            trace::verbose(_X("Found neither 'framework' nor 'frameworks' section in runtimeconfig.json file"));
+            return true;
+        }
+        
+        const auto& frameworks_array = frameworks->second.as_array();
+        if (frameworks_array.size() == 0)
+        {
+            return true;
+        }
+        
+        fx_obj = &frameworks_array.at(0).as_object(); // Using first element of frameworks array
+    }
+    else
+    {
+        fx_obj = &framework->second.as_object();
     }
 
     m_portable = true;
-
-    const auto& fx_obj = framework->second.as_object();
-    m_fx_name = fx_obj.at(_X("name")).as_string();
-    m_fx_ver = fx_obj.at(_X("version")).as_string();
+    m_fx_name = fx_obj->at(_X("name")).as_string();
+    m_fx_ver = fx_obj->at(_X("version")).as_string();
     return true;
 }
 

--- a/src/CoreCLREmbedding/host/runtime_config.cpp
+++ b/src/CoreCLREmbedding/host/runtime_config.cpp
@@ -75,18 +75,24 @@ bool runtime_config_t::parse_opts(const json_value& opts)
     auto framework = opts_obj.find(_X("framework"));
     const web::json::object* fx_obj = nullptr;
 
-    if (framework == opts_obj.end()) // Found no "framework" section in file, trying "frameworks"
+    if (framework == opts_obj.end()) // Found no "framework" section in file, trying "frameworks" or "includedFrameworks"
     {
         auto frameworks = opts_obj.find(_X("frameworks"));
         if (frameworks == opts_obj.end())
         {
-            trace::verbose(_X("Found neither 'framework' nor 'frameworks' section in runtimeconfig.json file"));
-            return true;
+            frameworks = opts_obj.find(_X("includedFrameworks"));
+
+            if (frameworks == opts_obj.end())
+            {
+                trace::verbose(_X("Found neither 'framework' nor 'frameworks' nor 'includedFrameworks' section in runtimeconfig.json file"));
+                return true;
+            }
         }
         
         const auto& frameworks_array = frameworks->second.as_array();
         if (frameworks_array.size() == 0)
         {
+            trace::verbose(_X("'Frameworks' in runtimeconfig.json file section found but is empty"));
             return true;
         }
         
@@ -100,6 +106,9 @@ bool runtime_config_t::parse_opts(const json_value& opts)
     m_portable = true;
     m_fx_name = fx_obj->at(_X("name")).as_string();
     m_fx_ver = fx_obj->at(_X("version")).as_string();
+
+    trace::verbose(_X("Found framework with version [%s] in runtimeconfig.json file"), m_fx_ver);
+
     return true;
 }
 


### PR DESCRIPTION
Edge-js currently does not work correctly when only using a .NET runtime. It currently requires an installed .NET SDK.

That is not feasible for production environments as they typically use only the .NET runtime as a prerequisite.

The reason for the difference appears to be that edge-js tries to find a dotnet.runtimeconfig.json file which is only available when using the .NET SDK.

However a .NET project can generate its own per-app runtimeconfig file. This file should be used preferably if present in the EDGE_APP_ROOT directory. If there is more than one file, an exception is thrown. If there is no file, it should revert to the current mechanism where the SDK runtimeconfig.json is used.