### PR TITLE
Reordered appconfig logic: Appname.Runtimeconfig as default; SDK runtimeconfig as fallback

### DIFF
--- a/src/CoreCLREmbedding/coreclrembedding.cpp
+++ b/src/CoreCLREmbedding/coreclrembedding.cpp
@@ -558,7 +558,7 @@ HRESULT CoreClrEmbedding::Initialize(BOOL debugMode)
 			runtimeconfigfile = pal::string_t(edgeAppDir);
 			append_path(&runtimeconfigfile, appConfigFiles[0].c_str());
 
-			trace::info(_X("CoreClrEmbedding::Initialize - No SDK directory found - Exactly one (%s) app runtimeconfig file found in the Edge app directory, using that"), runtimeconfigfile.c_str());
+			trace::info(_X("CoreClrEmbedding::Initialize - Exactly one (%s) app runtimeconfig file found in the Edge app directory, using that"), runtimeconfigfile.c_str());
 			configFile = pal::string_t(runtimeconfigfile);
 		}
 		if (!sdkDirectory.empty()) // Fallback: SDK is installed and found - using dotnet.runtimeconfig.json from SDK folder
@@ -566,7 +566,7 @@ HRESULT CoreClrEmbedding::Initialize(BOOL debugMode)
 			runtimeconfigfile = pal::string_t(sdkDirectory);
 			append_path(&runtimeconfigfile, _X("dotnet.dll"));
 
-			trace::info(_X("CoreClrEmbedding::Initialize - SDK directory found - Using dotnet.runtimeconfig.json from SDK folder"));
+			trace::info(_X("CoreClrEmbedding::Initialize - No app runtimeconfig file found, but SDK directory found - Using dotnet.runtimeconfig.json from SDK directory"));
 			get_runtime_config_paths_from_app(runtimeconfigfile, &configFile, &devConfigFile);
 		}
 		else if (appConfigFiles.size() > 1) // Throw error: No SDK found but more than one runtimeconfig.json found in app folder - Which one is correct?

--- a/src/CoreCLREmbedding/coreclrembedding.cpp
+++ b/src/CoreCLREmbedding/coreclrembedding.cpp
@@ -561,7 +561,7 @@ HRESULT CoreClrEmbedding::Initialize(BOOL debugMode)
 			trace::info(_X("CoreClrEmbedding::Initialize - Exactly one (%s) app runtimeconfig file found in the Edge app directory, using that"), runtimeconfigfile.c_str());
 			configFile = pal::string_t(runtimeconfigfile);
 		}
-		if (!sdkDirectory.empty()) // Fallback: SDK is installed and found - using dotnet.runtimeconfig.json from SDK folder
+		else if (!sdkDirectory.empty()) // Fallback: SDK is installed and found - using dotnet.runtimeconfig.json from SDK folder
 		{
 			runtimeconfigfile = pal::string_t(sdkDirectory);
 			append_path(&runtimeconfigfile, _X("dotnet.dll"));

--- a/src/CoreCLREmbedding/coreclrembedding.cpp
+++ b/src/CoreCLREmbedding/coreclrembedding.cpp
@@ -360,7 +360,7 @@ HRESULT CoreClrEmbedding::Initialize(BOOL debugMode)
 	{
 		dotnetExecutablePath = _X("");
 		dotnetDirectory = _X("");
-		trace::info(_X("CoreClrEmbedding::Initialize - dotnet not found in in DOTNET_ROOT"));
+		trace::info(_X("CoreClrEmbedding::Initialize - dotnet not found in DOTNET_ROOT"));
 	}
 
 	// 2. Get path to .NET from registry
@@ -553,19 +553,21 @@ HRESULT CoreClrEmbedding::Initialize(BOOL debugMode)
 
 		fx_muxer_t::resolve_sdk_dotnet_path(dotnetDirectory, &sdkDirectory);
 		
-		if (!sdkDirectory.empty()) // Default case: SDK is installed and found - using dotnet.runtimeconfig.json from SDK folder
-		{
-			runtimeconfigfile = pal::string_t(sdkDirectory);
-			append_path(&runtimeconfigfile, _X("dotnet.dll"));
-			get_runtime_config_paths_from_app(runtimeconfigfile, &configFile, &devConfigFile);
-		}
-		else if (appConfigFiles.size() == 1) // Fallback: No SDK directory found (probably only .NET runtime installed), trying to use [appname].runtimeconfig.json instead
+		if (appConfigFiles.size() == 1) // Default case: No SDK directory found (probably only .NET runtime installed), trying to use [appname].runtimeconfig.json instead
 		{
 			runtimeconfigfile = pal::string_t(edgeAppDir);
 			append_path(&runtimeconfigfile, appConfigFiles[0].c_str());
 
 			trace::info(_X("CoreClrEmbedding::Initialize - No SDK directory found - Exactly one (%s) app runtimeconfig file found in the Edge app directory, using that"), runtimeconfigfile.c_str());
 			configFile = pal::string_t(runtimeconfigfile);
+		}
+		if (!sdkDirectory.empty()) // Fallback: SDK is installed and found - using dotnet.runtimeconfig.json from SDK folder
+		{
+			runtimeconfigfile = pal::string_t(sdkDirectory);
+			append_path(&runtimeconfigfile, _X("dotnet.dll"));
+
+			trace::info(_X("CoreClrEmbedding::Initialize - SDK directory found - Using dotnet.runtimeconfig.json from SDK folder"));
+			get_runtime_config_paths_from_app(runtimeconfigfile, &configFile, &devConfigFile);
 		}
 		else if (appConfigFiles.size() > 1) // Throw error: No SDK found but more than one runtimeconfig.json found in app folder - Which one is correct?
 		{


### PR DESCRIPTION
The search for a viable runetimeconfig can be buggy. We had a user that had:

- .NET 8 SDK
- .NET 9 Runtime
- Appname.runtimeconfig.json in the edge app directory ("EDGE_APP_ROOT")

The current mechanism then tries running the edge app directory DLLs as .NET 8 causing a TypeLoadException as a .NET 9 library is being run with .NET 8 SDK.

StackTrace: '   at ClrFuncReflectionWrap.Create(Assembly assembly, String typeName, String methodName)\r\n' +
    '   at CoreCLREmbedding.GetFunc(String assemblyFile, String typeName, String methodName, IntPtr exception)',
  Name: 'System.TypeLoadException',
  name: 'System.TypeLoadException

This makes no sense as an appname.runtimeconfig.json should take precedence over the generic .NET SDK runtimeconfig as it is app-specific and tailormade for this app.

The changes switch the cases in the according if-statement and add a trace to the SDK-case to make clear it is a fallback-mechanism.

`Error: Could not load type 'XXX'
    at Object.func (C:\snapshot\s\node_modules\edge-js\lib\edge.js:174:17)
    at DefaultIdentityManagerInvoker.getOrCreateMethod (C:\snapshot\s\dist\apps\server\main.js)
    at C:\snapshot\s\dist\apps\server\main.js
    at new Promise (<anonymous>)
    at DefaultIdentityManagerInvoker.invokeIdentityManagerInternal (C:\snapshot\s\dist\apps\server\main.js)
    at DefaultIdentityManagerInvoker.initializeNodeCallbacks (C:\snapshot\s\dist\apps\server\main.js)
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async C:\snapshot\s\dist\apps\server\main.js
    at async IdentityService.warmupIdentityManagerInvoker (C:\snapshot\s\dist\apps\server\main.js)
    at async Array.<anonymous> (C:\snapshot\s\dist\apps\server\main.js) {
  Message: "Could not load type 'XXX'",
  TypeName: '',
  TargetSite: {
    Name: '',
    DeclaringType: '',
    ReflectedType: '',
    MemberType: '',
    MetadataToken: '',
    Module: '',
    IsSecurityCritical: '',
    IsSecuritySafeCritical: '',
    IsSecurityTransparent: '',
    MethodHandle: '',
    Attributes: '',
    CallingConvention: '',
    ReturnType: '',
    ReturnTypeCustomAttributes: '',
    ReturnParameter: '',
    IsCollectible: '',
    IsGenericMethod: '',
    IsGenericMethodDefinition: '',
    ContainsGenericParameters: '',
    MethodImplementationFlags: '',
    IsAbstract: '',
    IsConstructor: '',
    IsFinal: '',
    IsHideBySig: '',
    IsSpecialName: '',
    IsStatic: '',
    IsVirtual: '',
    IsAssembly: '',
    IsFamily: '',
    IsFamilyAndAssembly: '',
    IsFamilyOrAssembly: '',
    IsPrivate: '',
    IsPublic: '',
    IsConstructedGenericMethod: '',
    CustomAttributes: ''
  },
  Data: {},
  InnerException: null,
  HelpLink: null,
  Source: 'EdgeJs',
  HResult: -2146233054,
  StackTrace: '   at ClrFuncReflectionWrap.Create(Assembly assembly, String typeName, String methodName)\r\n' +
    '   at CoreCLREmbedding.GetFunc(String assemblyFile, String typeName, String methodName, IntPtr exception)',
  Name: 'System.TypeLoadException',
  name: 'System.TypeLoadException'`